### PR TITLE
Make scripts portable

### DIFF
--- a/helm.sh
+++ b/helm.sh
@@ -42,7 +42,7 @@ helm init --client-only >/dev/null
 # Remove local repo to increase reproducibility and remove errors
 helm repo list |grep -qc local && $BINARY repo remove local >/dev/null
 
-helm plugin list | grep -qc tiller || $BINARY plugin install $(dirname $(rlocation __main__/external/helm_tiller/WORKSPACE))
+helm plugin list | grep -qc tiller || $BINARY plugin install "$RUNFILES_DIR/helm_tiller"
 
 cd "${BUILD_WORKING_DIRECTORY:-}"
 helm $*

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -1,7 +1,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 HELM_CMD_PREFIX = """
-echo "#!/bin/bash" > $@
+echo "#!/usr/bin/env bash" > $@
 cat $(location @com_github_tmc_rules_helm//:runfiles_bash) >> $@
 echo "export NAMESPACE=$$(grep NAMESPACE bazel-out/stable-status.txt | cut -d ' ' -f 2)" >> $@
 echo "export BUILD_USER=$$(grep BUILD_USER bazel-out/stable-status.txt | cut -d ' ' -f 2)" >> $@

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ./tools/buildifier -mode=check "$(find "${BUILD_WORKSPACE_DIRECTORY}" -name BUILD -or -name BUILD.bazel )"

--- a/tools/lintfix.sh
+++ b/tools/lintfix.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ./tools/buildifier -mode=fix "$(find "${BUILD_WORKSPACE_DIRECTORY}" -name BUILD -or -name BUILD.bazel -or -name *.bzl )"


### PR DESCRIPTION
The path `/bin/bash` is not standard, but `/usr/bin/env` is. To give some context, I was trying to use this on NixOS and it wasn't working.