### PR TITLE
updated helm 3 version

### DIFF
--- a/repos.bzl
+++ b/repos.bzl
@@ -12,15 +12,15 @@ def helm_repositories():
 
     http_archive(
         name = "helm",
-        sha256 = "12632bdf85144d8883de07d257f892f447a8bccc84de82276e111059ac8437b1",
-        urls = ["https://get.helm.sh/helm-v3.0.0-alpha.1-linux-amd64.tar.gz"],
+        sha256 = "cdd7ad304e2615c583dde0ffb0cb38fc1336cd7ce8ff3b5f237434dcadb28c98",
+        urls = ["https://get.helm.sh/helm-v3.1.1-linux-amd64.tar.gz"],
         build_file = "@com_github_tmc_rules_helm//:helm.BUILD",
         #
     )
 
     http_archive(
         name = "helm_osx",
-        sha256 = "f562e5bbb5b8b8a6a46c080970c1fea35ff908a1402f56e5d4c8f327c9ff4835",
-        urls = ["https://get.helm.sh/helm-v3.0.0-alpha.1-darwin-amd64.tar.gz"],
+        sha256 = "2ce00e6c44ba18fbcbec21c493476e919128710d480789bb35bd228ae695cd66",
+        urls = ["https://get.helm.sh/helm-v3.1.1-darwin-amd64.tar.gz"],
         build_file = "@com_github_tmc_rules_helm//:helm.BUILD",
     )


### PR DESCRIPTION
As the loaded alpha version does not take the --namespace command line arg, I upgraded the helm version to the latest one